### PR TITLE
Fix to allow pure JSON to be posted on save

### DIFF
--- a/src/plugins/save/jquery.ui.editor.savejson.js
+++ b/src/plugins/save/jquery.ui.editor.savejson.js
@@ -213,7 +213,12 @@ $.ui.editor.registerPlugin('saveJson', /** @lends $.editor.plugin.saveJson.proto
             ajax.data = ajax.data.apply(this, [id, contentData]);
         } else if (this.options.postName) {
             ajax.data = {};
-            ajax.data[this.options.postName] = JSON.stringify(contentData);
+            if (this.options.ajax.processData) {
+                ajax.data[this.options.postName] = JSON.stringify(contentData);
+            } else {
+                ajax.data[this.options.postName] = contentData;
+                ajax.data = JSON.stringify(ajax.data);
+            }
         }
 
         // Get the URL, if it is a callback


### PR DESCRIPTION
The current design of raptor by default does a strange hybrid of a querystring containing the urlencoded json string. I think this may make some sense for some server code for example it may suit the way php exposes the $_POST array more cleanly than accessing the body directly, but...the majority of services that receive payloads as 'application/json' would expect the body to be pure json, and this i think would be more pure.

As $.ajax() ignores contentType when it decides on the serialisation scheme, the json is urlencoded, or if processData is false then it passes the [Object object] string, so we still need to stringify.

processData in the ajax documentation is there to explicitly urlencode or not, so if Raptor sees this option is fasle then its fair to assume the client code wants a raw json serialisation of the payload to be sent.

For now I am using a function to provide the data (thanks for considering that flexibility), as anyone could, but I feel this pull would be a sensible inclusion.

This fix may be relevant to the saveRest - but I struggle to see what saveRest does that saveJson doesn't.
